### PR TITLE
Update index.hbs static assets to be relative paths for local dev

### DIFF
--- a/templates/index.hbs
+++ b/templates/index.hbs
@@ -16,9 +16,9 @@
   <base href="{{baseHref}}" />
   {{!-- Fonts  --}}
   <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:400,600" rel="stylesheet" type="text/css">
-  <link href="/open-source/radium/static/fonts.css" rel="stylesheet" type="text/css">
+  <link href="./static/fonts.css" rel="stylesheet" type="text/css">
   <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.0.0/codemirror.min.css"/>
-  <link href="/open-source/radium/static/prism-github-dark.css" rel="stylesheet" type="text/css">
+  <link href="./static/prism-github-dark.css" rel="stylesheet" type="text/css">
 </head>
 <body>
   <div id="content" style="height: 100vh">{{{content}}}</div>


### PR DESCRIPTION
Previously, `builder run server-static` wouldn't work due to the hardcoded `/open-source/radium/` path

/cc @paulathevalley @kylecesmat 