### PR TITLE
Switch to markdown-it for better link/header customization

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,18 +20,19 @@
   },
   "homepage": "https://github.com/FormidableLabs/radium-docs#readme",
   "devDependencies": {
-    "builder-docs-archetype-dev": "^2.0.0"
+    "builder-docs-archetype-dev": "^2.0.1"
   },
   "dependencies": {
     "babel-preset-stage-1": "^6.5.0",
     "builder": "^2.9.1",
-    "builder-docs-archetype": "^2.0.0",
+    "builder-docs-archetype": "^2.0.1",
     "chai": "^3.2.0",
     "color": "^0.11.3",
     "ecology": "^1.5.2",
     "formidable-landers": "^3.1.0",
     "history": "~1.17.0",
-    "marked": "^0.3.5",
+    "markdown-it": "^7.0.0",
+    "markdown-it-named-headers": "0.0.4",
     "prismjs": "^1.5.1",
     "radium": "*",
     "react": "15.2.1",

--- a/src/basename.js
+++ b/src/basename.js
@@ -1,0 +1,2 @@
+const basename = process.env.NODE_ENV === "production" ? "/open-source/radium" : "";
+export default basename;

--- a/src/components/entry.js
+++ b/src/components/entry.js
@@ -7,17 +7,14 @@ import useScroll from "react-router-scroll";
 
 import Index from "../../templates/index.hbs";
 import routes from "../routes";
-
-const routing = {
-  base: process.env.NODE_ENV === "production" ? "/open-source/radium" : ""
-};
+import basename from "../basename";
 
 // Client render (optional):
 // `static-site-generator-webpack-plugin` supports shimming browser globals
 // so instead of checking whether the document is undefined (always false),
 // Check whether it’s being shimmed
 if (typeof window !== "undefined" && window.__STATIC_GENERATOR !== true) { //eslint-disable-line no-undef
-  const history = useRouterHistory(createHistory)({ basename: routing.base });
+  const history = useRouterHistory(createHistory)({ basename });
   render(
     <Router
       history={history}
@@ -36,7 +33,7 @@ export default (locals, callback) => {
     callback(null, Index({
       content: renderToString(<RouterContext {...renderProps} />),
       bundleJs: locals.assets.main,
-      baseHref: `${routing.base}/`
+      baseHref: `${basename}/`
     }));
   });
 };

--- a/src/views/docs/index.js
+++ b/src/views/docs/index.js
@@ -43,6 +43,10 @@ class Docs extends React.Component {
     }
   }
 
+  getChildContext() {
+    return { location: this.props.location };
+  }
+
   collapseMenuForSmallerScreens() {
     const breakpoint = "945px";
     if (window.matchMedia(`(max-width: ${breakpoint})`).matches && this.state.menuOpen) {
@@ -104,7 +108,12 @@ class Docs extends React.Component {
 }
 
 Docs.propTypes = {
-  params: React.PropTypes.object.isRequired
+  params: React.PropTypes.object.isRequired,
+  location: React.PropTypes.object.isRequired
+};
+
+Docs.childContextTypes = {
+  location: React.PropTypes.object
 };
 
 export default Radium(Docs);


### PR DESCRIPTION
- Expose basename to client in a shared `basename.js` file, used when generating relative anchor links
- Set router location in context for access on server and client inside of docs component
- Switch to markdown-it for easier extensibility
- Customize markdown-it link renderer to prefix anchor links with basename + pathname, set during `componentWillUpdate`

/cc @coopy @kylecesmat 

Resolves https://github.com/FormidableLabs/radium-docs/issues/12