### PR TITLE
Adjust mobile styles in header

### DIFF
--- a/src/radium-theme.js
+++ b/src/radium-theme.js
@@ -30,8 +30,7 @@ module.exports = {
   // Media Queries
   // --------
   mediaSizes: {
-    medium: "only screen and (min-width: 44.063em)",
-    small: "only screen and (max-width: 44em)"
+    medium: "only screen and (min-width: 44.063em)"
   },
   // ---------------------
   // CodeMirror Theme

--- a/src/radium-theme.js
+++ b/src/radium-theme.js
@@ -30,7 +30,8 @@ module.exports = {
   // Media Queries
   // --------
   mediaSizes: {
-    medium: "only screen and (min-width: 44em)"
+    medium: "only screen and (min-width: 44.063em)",
+    small: "only screen and (max-width: 44em)"
   },
   // ---------------------
   // CodeMirror Theme

--- a/src/views/home/components/hero.js
+++ b/src/views/home/components/hero.js
@@ -11,42 +11,63 @@ class Hero extends React.Component {
     return {
       header: {
         backgroundColor: "#050505",
-        backgroundImage: `url(./static/bg-radium.jpg)`,
+        backgroundImage: "url(./static/bg-radium.jpg)",
         backgroundPosition: "bottom center",
         backgroundRepeat: "no-repeat",
         backgroundSize: "cover",
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "center",
-        justifyContent: "space-around",
-        minHeight: "650px",
-        padding: "10% 1rem 2rem",
-        height: "80vh"
+        height: "80vh",
+        [`@media ${theme.mediaSizes.medium}`]: {
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "space-around",
+          minHeight: "650px",
+          padding: "10% 1rem 2rem"
+        },
+        [`@media ${theme.mediaSizes.small}`]: {
+          minHeight: "580px",
+          padding: "5% .5rem 1rem"
+        }
       },
       intro: {
         display: "flex",
-        flexDirection: "row",
-        flexWrap: "wrap",
         justifyContent: "space-between",
         margin: "auto",
         padding: 0,
         width: "auto",
         [`@media ${theme.mediaSizes.medium}`]: {
           flexWrap: "nowrap"
+        },
+        [`@media ${theme.mediaSizes.small}`]: {
+          justifyContent: "center",
+          flexDirection: "column",
+          flexWrap: "wrap"
         }
       },
       logo: {
-        flex: "0 1 360px",
-        marginRight: "3.75rem"
+        [`@media ${theme.mediaSizes.medium}`]: {
+          flex: "0 1 360px",
+          marginRight: "3.75rem"
+        },
+        [`@media ${theme.mediaSizes.small}`]: {
+          maxWidth: "180px",
+          margin: "0 auto"
+        }
       },
       copy: {
         color: theme.white,
-        flex: "1 1 auto"
+        flex: "1 1 auto",
+        [`@media ${theme.mediaSizes.small}`]: {
+          textAlign: "center"
+        }
       },
       heading: {
         fontFamily: theme.sansSerif,
         MozOsxFontSmoothing: "grayscale",
-        WebkitFontSmoothing: "antialiased"
+        WebkitFontSmoothing: "antialiased",
+        [`@media ${theme.mediaSizes.small}`]: {
+          margin: "0"
+        }
       },
       paragraph: {
         fontFamily: theme.monospace,
@@ -54,7 +75,10 @@ class Hero extends React.Component {
         lineHeight: "1.5",
         maxWidth: "30em",
         MozOsxFontSmoothing: "grayscale",
-        WebkitFontSmoothing: "antialiased"
+        WebkitFontSmoothing: "antialiased",
+        [`@media ${theme.mediaSizes.small}`]: {
+          margin: "0 auto"
+        }
       },
       installer: {
         backgroundColor: theme.charcoal,
@@ -62,7 +86,11 @@ class Hero extends React.Component {
         marginBottom: "5rem",
         maxWidth: "30em",
         padding: "2em",
-        textAlign: "center"
+        textAlign: "center",
+        [`@media ${theme.mediaSizes.small}`]: {
+          margin: "2rem auto",
+          padding: "1em"
+        }
       },
       installerHeading: {
         color: theme.white,
@@ -85,20 +113,26 @@ class Hero extends React.Component {
         flexDirection: "row",
         flexWrap: "wrap",
         fontFamily: theme.monospace,
+        margin: 0,
+        padding: 0,
+        width: "100%",
         MozOsxFontSmoothing: "grayscale",
         WebkitFontSmoothing: "antialiased",
-        fontSize: "0.875rem",
         justifyContent: "space-between",
         letterSpacing: "0.09em",
         listStyle: "none",
-        margin: "1rem -1.5em",
-        padding: 0,
         textTransform: "uppercase",
-        width: "100%"
+        [`@media ${theme.mediaSizes.medium}`]: {
+          margin: "1rem -1.5em"
+        }
       },
       navListItem: {
-        padding: "1.5em",
-        fontSize: "14px"
+        padding: "1em",
+        fontSize: "12px",
+        [`@media ${theme.mediaSizes.medium}`]: {
+          padding: "1.5em",
+          fontSize: "14px"
+        }
       },
       logoGithub: {
         color: "inherit",

--- a/src/views/home/components/hero.js
+++ b/src/views/home/components/hero.js
@@ -10,12 +10,17 @@ class Hero extends React.Component {
   getHeroStyles() {
     return {
       header: {
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        minHeight: "580px",
+        height: "80vh",
+        padding: "5% .5rem 1rem",
         backgroundColor: "#050505",
         backgroundImage: "url(./static/bg-radium.jpg)",
         backgroundPosition: "bottom center",
         backgroundRepeat: "no-repeat",
         backgroundSize: "cover",
-        height: "80vh",
         [`@media ${theme.mediaSizes.medium}`]: {
           display: "flex",
           flexDirection: "column",
@@ -23,50 +28,46 @@ class Hero extends React.Component {
           justifyContent: "space-around",
           minHeight: "650px",
           padding: "10% 1rem 2rem"
-        },
-        [`@media ${theme.mediaSizes.small}`]: {
-          minHeight: "580px",
-          padding: "5% .5rem 1rem"
         }
       },
       intro: {
         display: "flex",
-        justifyContent: "space-between",
+        justifyContent: "center",
+        flexDirection: "column",
+        flexWrap: "wrap",
         margin: "auto",
         padding: 0,
         width: "auto",
         [`@media ${theme.mediaSizes.medium}`]: {
-          flexWrap: "nowrap"
-        },
-        [`@media ${theme.mediaSizes.small}`]: {
-          justifyContent: "center",
-          flexDirection: "column",
-          flexWrap: "wrap"
+          flexWrap: "nowrap",
+          flexDirection: "row",
+          justifyContent: "space-between"
         }
       },
       logo: {
+        maxWidth: "180px",
+        margin: "0 auto",
         [`@media ${theme.mediaSizes.medium}`]: {
+          maxWidth: "initial",
           flex: "0 1 360px",
-          marginRight: "3.75rem"
-        },
-        [`@media ${theme.mediaSizes.small}`]: {
-          maxWidth: "180px",
-          margin: "0 auto"
+          margin: "0 3.75rem 0 0"
         }
       },
       copy: {
+        textAlign: "center",
         color: theme.white,
         flex: "1 1 auto",
-        [`@media ${theme.mediaSizes.small}`]: {
-          textAlign: "center"
+        [`@media ${theme.mediaSizes.medium}`]: {
+          textAlign: "left"
         }
       },
       heading: {
+        margin: "0em",
         fontFamily: theme.sansSerif,
         MozOsxFontSmoothing: "grayscale",
         WebkitFontSmoothing: "antialiased",
-        [`@media ${theme.mediaSizes.small}`]: {
-          margin: "0"
+        [`@media ${theme.mediaSizes.medium}`]: {
+          margin: ".25em 0"
         }
       },
       paragraph: {
@@ -74,22 +75,19 @@ class Hero extends React.Component {
         fontSize: "0.875rem",
         lineHeight: "1.5",
         maxWidth: "30em",
+        margin: "0 auto",
         MozOsxFontSmoothing: "grayscale",
-        WebkitFontSmoothing: "antialiased",
-        [`@media ${theme.mediaSizes.small}`]: {
-          margin: "0 auto"
-        }
+        WebkitFontSmoothing: "antialiased"
       },
       installer: {
         backgroundColor: theme.charcoal,
-        marginTop: "2rem",
-        marginBottom: "5rem",
+        margin: "2rem auto",
+        padding: "1em",
         maxWidth: "30em",
-        padding: "2em",
         textAlign: "center",
-        [`@media ${theme.mediaSizes.small}`]: {
-          margin: "2rem auto",
-          padding: "1em"
+        [`@media ${theme.mediaSizes.medium}`]: {
+          margin: "2rem 0 5rem",
+          padding: "2em"
         }
       },
       installerHeading: {


### PR DESCRIPTION
This will fix the header layout on mobile devices. The rest of the site appears to respond well on mobile, so this PR only affects the header. Closes https://github.com/FormidableLabs/radium-docs/issues/18

- Center-align logo & text on screens <= 705px
- Links have reduced padding, layout well across screens
- Header size has been adjusted slightly

cc @paulathevalley 

Previews:
![screen shot 2016-07-22 at 10 58 16 am](https://cloud.githubusercontent.com/assets/1633837/17066411/d322bfee-4ffb-11e6-9799-47c3732dd031.png)
![screen shot 2016-07-22 at 10 58 41 am](https://cloud.githubusercontent.com/assets/1633837/17066409/d3217562-4ffb-11e6-9a57-27d1854989b0.png)
![screen shot 2016-07-22 at 10 58 57 am](https://cloud.githubusercontent.com/assets/1633837/17066410/d3221f76-4ffb-11e6-8a85-09f6def2b7a3.png)
![screen shot 2016-07-22 at 10 59 07 am](https://cloud.githubusercontent.com/assets/1633837/17066408/d3213e80-4ffb-11e6-9a10-de82f9715d6a.png)
