### PR TITLE
Fix Server-Rendered CSS

### DIFF
--- a/src/components/app.js
+++ b/src/components/app.js
@@ -11,10 +11,14 @@ class App extends React.Component {
   }
 
   render() {
+    const isBrowser = typeof window !== "undefined" && window.__STATIC_GENERATOR !== true;
     return (
-      <StyleRoot style={{display: "flex", flexDirection: "column", height: "100%"}}>
-        {this.props.children}
+      <StyleRoot
+        radiumConfig={isBrowser ? { userAgent: window.navigator.userAgent } : null}
+        style={{display: "flex", flexDirection: "column", height: "100%"}}
+      >
         <Style rules={stylesheet} />
+        {this.props.children}
       </StyleRoot>
     );
   }

--- a/src/components/entry.js
+++ b/src/components/entry.js
@@ -27,6 +27,10 @@ if (typeof window !== "undefined" && window.__STATIC_GENERATOR !== true) { //esl
 
 // Exported static site renderer:
 export default (locals, callback) => {
+  global.navigator = {
+    userAgent: "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2454.85 Safari/537.36"
+  };
+
   const history = createMemoryHistory();
   const location = history.createLocation(locals.path);
   match({ routes, location }, (error, redirectLocation, renderProps) => {


### PR DESCRIPTION
This will place the `<Style>` component above the children, making global styles load first. The useragent correctly sets the prefixing for Radium serverside.

This will fix #25 

cc @paulathevalley @bmathews 