### PR TITLE
Fix broken links in header

### DIFF
--- a/src/components/hyperlink.js
+++ b/src/components/hyperlink.js
@@ -31,6 +31,12 @@ class Hyperlink extends React.Component {
         ":hover": {
           color: settings.lightGray
         }
+      },
+      none: {
+        color: "auto",
+        ":hover": {
+          color: "auto"
+        }
       }
     };
   }
@@ -70,7 +76,7 @@ Hyperlink.propTypes = {
   children: React.PropTypes.node,
   destination: React.PropTypes.oneOf(["internal", "external"]).isRequired,
   href: React.PropTypes.string.isRequired,
-  theme: React.PropTypes.oneOf(["onDark"]),
+  theme: React.PropTypes.oneOf(["onDark", "none"]),
   style: React.PropTypes.object
 };
 

--- a/src/views/docs/index.js
+++ b/src/views/docs/index.js
@@ -4,6 +4,7 @@ import Sidebar from "./components/sidebar";
 import Documentation from "./components/docs";
 import { find } from "lodash";
 import { documents } from "./components/radium-files";
+import RadiumLink from "../../components/hyperlink";
 
 import { Header } from "formidable-landers";
 
@@ -102,9 +103,15 @@ class Docs extends React.Component {
       >
         <Header padding="1.5rem 1rem">
           <div className="default">
-            <a href="/docs">Docs</a>
-            <a href="//github.com/FormidableLabs/radium/issues">Issues</a>
-            <a href="//github.com/FormidableLabs/radium">View Source on GitHub</a>
+            <RadiumLink destination="internal" href="/docs" theme="none">
+              Docs
+            </RadiumLink>
+            <RadiumLink destination="external" href="https://github.com/FormidableLabs/radium/issues" theme="none">
+              Issues
+            </RadiumLink>
+            <RadiumLink destination="external" href="https://github.com/FormidableLabs/radium" theme="none">
+              View Source on GitHub
+            </RadiumLink>
           </div>
         </Header>
         <main style={styles.main}>

--- a/src/views/home/index.js
+++ b/src/views/home/index.js
@@ -86,9 +86,15 @@ class Home extends React.Component {
           }}
         />
           <div className="default">
-            <a href="/docs">Docs</a>
-            <a href="//github.com/FormidableLabs/radium/issues">Issues</a>
-            <a href="//github.com/FormidableLabs/radium">View Source on GitHub</a>
+            <RadiumLink destination="internal" href="/docs" theme="none">
+              Docs
+            </RadiumLink>
+            <RadiumLink destination="external" href="https://github.com/FormidableLabs/radium/issues" theme="none">
+              Issues
+            </RadiumLink>
+            <RadiumLink destination="external" href="https://github.com/FormidableLabs/radium" theme="none">
+              View Source on GitHub
+            </RadiumLink>
           </div>
         </Header>
         <Hero />


### PR DESCRIPTION
Need to use `<Link>` for navigating to internal routes! Add a "none" theme to the `Hyperlink` component so that it will inherit colors set by the `formidable-landers` components.

/cc @ebrillhart @bmathews 